### PR TITLE
feat: Remove the close methods from the clients.

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,7 +7,7 @@ build:
     uv build
 
 # install project deps
-sync:
+install:
     uv sync --group dev --group lint --group test
 
 # check code

--- a/Justfile
+++ b/Justfile
@@ -7,7 +7,7 @@ build:
     uv build
 
 # install project deps
-install:
+sync:
     uv sync --group dev --group lint --group test
 
 # check code

--- a/openmeteo_requests/Client.py
+++ b/openmeteo_requests/Client.py
@@ -47,7 +47,6 @@ class Client:
     def __init__(self, session: niquests.Session | None = None) -> None:
         self._session = session or niquests.Session()
         self._response_cls = WeatherApiResponse
-        self._closed: bool | None = None
 
     def _request(
         self,
@@ -87,10 +86,6 @@ class Client:
     ) -> list[WeatherApiResponse]:
         """Get and decode as weather api"""
         try:
-            if self._closed:
-                msg = "Unavailable connection"
-                raise ConnectionError(msg)
-
             return self._request(
                 url=url,
                 method=method,
@@ -101,12 +96,6 @@ class Client:
         except Exception as e:
             msg = f"failed to request {url!r}: {e}"
             raise OpenMeteoRequestsError(msg) from e
-
-    def close(self) -> None:
-        """Close the client."""
-        # closing session may not be enough here (niquests)
-        self._session.close()
-        self._closed = True
 
 
 # pylint: disable=too-few-public-methods
@@ -169,7 +158,3 @@ class AsyncClient:
         except Exception as e:
             msg = f"failed to request {url!r}: {e}"
             raise OpenMeteoRequestsError(msg) from e
-
-    async def close(self) -> None:
-        """Close the client."""
-        await self._session.close()

--- a/openmeteo_requests/Client.py
+++ b/openmeteo_requests/Client.py
@@ -59,14 +59,12 @@ class Client:
     ) -> list[WeatherApiResponse]:
         params["format"] = _FLAT_BUFFERS_FORMAT
 
-        if method.upper() == HTTPVerb.GET:
-            response = self._session.get(
-                url, params=params, verify=verify, **kwargs
-            )
-        if method.upper() == HTTPVerb.POST:
-            response = self._session.post(
-                url, data=params, verify=verify, **kwargs
-            )
+        with self._session as sess:
+            method = method.upper()
+            if method == HTTPVerb.GET:
+                response = sess.get(url, params=params, verify=verify, **kwargs)
+            if method == HTTPVerb.POST:
+                response = sess.post(url, data=params, verify=verify, **kwargs)
 
         if response.status_code in [400, 429]:
             response_body = response.json()
@@ -120,11 +118,11 @@ class AsyncClient:
         response: niquests.Response
         async with self._session as sess:
             method = method.upper()
-            if method == "GET":
+            if method == HTTPVerb.GET:
                 meth = partial(
                     sess.get, url, params=params, verify=verify, **kwargs
                 )
-            if method == "POST":
+            if method == HTTPVerb.POST:
                 meth = partial(
                     sess.post, url, data=params, verify=verify, **kwargs
                 )

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -80,18 +80,9 @@ class TestClient:
         assert temperature_2m.ValuesLength() == 48
         assert precipitation.ValuesLength() == 48
 
-    def test_client_close(
-        self, client: Client, url: str, params: _ParamsType
-    ) -> None:
-        responses = client.weather_api(url=url, params=params)
-        assert responses
-
-        client.close()
-
+    def test_empty_url_error(self, client: Client, params: _ParamsType) -> None:
         with pytest.raises(OpenMeteoRequestsError):
-            client.weather_api(url=url, params=params)
-
-        client.close()  # does not break - idempotency
+            client.weather_api(url="", params=params)
 
 
 @pytest.mark.asyncio
@@ -132,18 +123,11 @@ class TestAsyncClient:
         assert temperature_2m.ValuesLength() == 48
         assert precipitation.ValuesLength() == 48
 
-    async def test_async_client_close(
-        self, async_client: AsyncClient, url: str, params: _ParamsType
+    async def test_empty_url_error(
+        self, async_client: AsyncClient, params: _ParamsType
     ) -> None:
-        responses = await async_client.weather_api(url=url, params=params)
-        assert responses
-
-        await async_client.close()
-
         with pytest.raises(OpenMeteoRequestsError):
-            await async_client.weather_api(url=url, params=params)
-
-        await async_client.close()  # does not break - idempotency
+            await async_client.weather_api(url="", params=params)
 
 
 def test_int_client():


### PR DESCRIPTION
In the previous PR #87 I injected the "close" methods into "Client" classes and I think this was a mistake. In this PR I want to fix it by removing these methods.

The rationale is that a user can have one session and multiple clients. A client only uses a session object and do not create it or own it in a way that the clients has the right to close the session in use. If one session as an external resource is shareable among many clients and one "decides" to close the session, the state of other clients gets invalidated which is undesirable. By this reason the "close" methods are better to be stripped from the "Client" classes.

Extra features:
- use `with session` in the "Client" class like in the "AsyncClient"
- use the `HTTPVerb` enum in the "AsyncClient" class like in the "Client"